### PR TITLE
feat: add Application struct and run method to Gazelle application

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -1,0 +1,10 @@
+// Application is the entry point for a Gazelle application
+pub struct Application {
+
+}
+
+impl Application {
+    pub fn run(&mut self) {
+        println!("This is running!")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,2 @@
-pub fn run() {
-    println!("This is running!")
-}
+// Declare Modules
+pub mod application;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,10 @@
-use gazelle::run;
+// The main.rs file exists as a Sandboxing environment for the Gazelle application.
+use gazelle::application;
 
 fn main() {
-    run();
+    let mut sandbox = application::Application {
+
+    };
+
+    sandbox.run();
 }


### PR DESCRIPTION
The Application struct is added to serve as the entry point for the Gazelle application. It contains a run method that will be used to start the application.